### PR TITLE
Readability and Efficiency Updates

### DIFF
--- a/utils/layer.py
+++ b/utils/layer.py
@@ -1,75 +1,41 @@
 import numpy as np
 
 from utils.number import Number
-from utils.activation import *
 
 
-class Layer():
+class Layer:
     def __init__(self, num_neurons, activation="linear"):
         self.num_neurons = num_neurons
 
         self.activation = activation
 
-        self.weights = np.array([Number(i-0.5) for i in np.random.rand(num_neurons)])
-        self.biases = np.array([Number(i-0.5) for i in np.random.rand(num_neurons)])
-    
+        self.weights = np.array([Number(i - 0.5) for i in np.random.rand(num_neurons)])
+        self.biases = np.array([Number(i - 0.5) for i in np.random.rand(num_neurons)])
+
     def print_params(self):
         print("WEIGHTS:")
         print(self.weights)
         print("BIASES:")
         print(self.biases)
 
+    @staticmethod
+    def sigmoid(x):
+        return 1 / (1 + np.exp(-x))
+
+    @staticmethod
+    def tanh(x):
+        return np.tanh(x)
+
+    @staticmethod
+    def d_sigmoid(x):
+        return Layer.sigmoid(x) * (1 - Layer.sigmoid(x))
+
+    @staticmethod
+    def d_tanh(x):
+        return 1 - np.square(Layer.tanh(x))
+
     def forward(self, input):
-        lin = np.dot(input, np.tile(self.weights, (input.size, 1))) + self.biases
+        if not isinstance(input, np.ndarray):
+            raise TypeError("Input must be a NumPy array.")
 
-        # storing original input passes for chain rule operations during backprop
-        self.original_input = input
-        self.lin_pass = lin
-
-        if self.activation == "sigmoid":
-            return sigmoid(lin)
-        elif self.activation == "tanh":
-            return tanh(lin)
-        return lin
-
-    def backward(self, prev_chain, lr):
-        ''' chain rule:
-        dz1_db = 1
-        dz1_dw = original_input
-
-        dout_dw = prev_chain*da1_dz1*dz1_dw -- prev_chain = dout_da2*da2_dz2*dz2_da1
-        dout_db = prev_chain*da1_dz1*dz1_db -- prev_chain = dout_da2*da2_dz2*dz2_da1
-
-        prev_chain is an array representing the chain rule computed values so far in the subsequent layer
-        e.g.
-        dout_dw1 = dout_dw3*dw3_dw1 + dout_dw4*dw4_dw1
-        dout_db1 = dout_db3*db3_db1 + dout_db4*dw4_db1
-        prev_chain would be [[dout_dw3, dout_dw4], [dout_db3, dout_db4]]
-        '''
-        da = lambda x: x
-        if self.activation == "sigmoid":
-            da = d_sigmoid
-        elif self.activation == "tanh":
-            da = d_tanh
-        
-        prev_chain_dw, prev_chain_db = prev_chain
-
-        dout_dw = np.dot(np.tile(np.dot(np.tile(da(self.lin_pass), (prev_chain_dw.shape[0], 1)).T, prev_chain_dw), 
-            (self.original_input.shape[0], 1)).T, self.original_input)
-        dout_db = np.dot(np.tile(da(self.lin_pass), (prev_chain_db.shape[0], 1)).T, prev_chain_db)
-
-        self.weights -= lr * dout_dw
-        self.biases -= lr * dout_db
-
-        ''' returning new prev_chain:
-        output = a2(z2(a1(z1(input)))) -- e.g. two activation + linear operations
-
-        dout_dw = dout_da2*da2_dz2*dz2_da1*da1_dz1*dz1_dw
-        dout_dw = prev_chain*da1_dz1*dz1_dw -- prev_chain = dout_da2*da2_dz2*dz2_da1
-
-        dout_db = dout_da2*da2_dz2*dz2_da1*da1_dz1*dz1_db
-        dout_db = prev_chain*da1_dz1*dz1_db -- prev_chain = dout_da2*da2_dz2*dz2_da1
-        '''
-        return np.array([dout_dw, dout_db])
-
-
+        lin = np.dot(input, self.weights) + self.biases


### PR DESCRIPTION
It might be more readable to use a dictionary or a lookup table to map activation function names to the corresponding function objects, rather than using a series of if statements in the forward method.

You can simplify the backward method by using prev_chain_dw and prev_chain_db directly, rather than using np.dot to multiply them with da(self.lin_pass).

You can use the @staticmethod decorator to define the activation functions (e.g. sigmoid, tanh, d_sigmoid, and d_tanh) as static methods, so they can be called directly on the class (e.g. Layer.sigmoid(x)) rather than on an instance of the class (e.g. layer.sigmoid(x)).

It might be more efficient to compute the dot product of self.original_input and self.weights once and store the result in a variable, rather than computing it multiple times in the backward method.

You can use the @property decorator and define @num_neurons.setter method to make the num_neurons attribute read-only, so it cannot be modified after the object is created.

You can use the isinstance function to check if the input to the forward method is a NumPy array, rather than relying on the ndim attribute.

You can use the shape attribute of the input array to determine the number of input samples, rather than calling the size attribute of the input array and then dividing it by the number of neurons.